### PR TITLE
BP-60:version playerData route

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
-    "python.testing.pytestArgs": [
-        "Utilities"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+  "python.testing.pytestArgs": ["Utilities"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true,
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/Server/src/routes/gameRoute.ts
+++ b/Server/src/routes/gameRoute.ts
@@ -82,7 +82,8 @@ gameRoute.get('/gameData/delta/:year', async (req: Request, res: Response) => {
   let query = `SELECT * FROM bowlGames 
                     WHERE homeTeam > ${teamIdRange.lowerBound} 
                     AND homeTeam < ${teamIdRange.upperBound}
-                    AND version > ${version}`;
+                    AND version > ${version}
+                    OR version = 0`;
   let values = [];
   connection.query(query, function (err: Error, results: BowlGame[]) {
     if (err) throw console.error(err);
@@ -90,7 +91,8 @@ gameRoute.get('/gameData/delta/:year', async (req: Request, res: Response) => {
     query = `SELECT * FROM bowlTeams 
                 WHERE teamId > ${teamIdRange.lowerBound} 
                 AND teamId < ${teamIdRange.upperBound}
-                AND version > ${version}`;
+                AND version > ${version}
+                OR version = 0`;
     connection.query(query, function (err: Error, result: BowlTeam[]) {
       let bowlTeams = JSON.parse(JSON.stringify(result));
       let mergedResults = createBowlGames(bowlGames, bowlTeams);

--- a/Server/src/routes/gameRoute.ts
+++ b/Server/src/routes/gameRoute.ts
@@ -72,7 +72,7 @@ gameRoute.get('/gameData/:year', async (req: Request, res: Response) => {
 
 export const gameRouteDelta = express.Router();
 gameRoute.get('/gameData/delta/:year', async (req: Request, res: Response) => {
-  var version = 0;
+  var version = -1;
   if (!isEmpty(req.query.version)) {
     version = parseInt(req.query.version as string);
     version = version == 0 ? -1 : version;

--- a/Server/src/routes/gameRoute.ts
+++ b/Server/src/routes/gameRoute.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response } from 'express';
 import { connection } from '../helpers/db';
 import { getTeamIdRange } from '../helpers/teamId';
-import _, { get, isEmpty } from 'lodash';
+import _, { isEmpty } from 'lodash';
 import { getCurrentVersion } from './versionUtil';
 
 export interface BowlGame {
@@ -66,7 +66,7 @@ gameRoute.get('/gameData/:year', async (req: Request, res: Response) => {
       });
     });
   } else {
-    res.send({ version: currentVersion });
+    res.send({ version: currentVersion, bowlData: [] });
   }
 });
 
@@ -76,7 +76,7 @@ gameRoute.get('/gameData/delta/:year', async (req: Request, res: Response) => {
   if (!isEmpty(req.query.version)) {
     version = parseInt(req.query.version as string);
   }
-  let year = req.params['year']
+  let year = req.params['year'];
   let currentVersion = await getCurrentVersion(year);
   let teamIdRange = getTeamIdRange(year);
   let query = `SELECT * FROM bowlGames 
@@ -94,7 +94,7 @@ gameRoute.get('/gameData/delta/:year', async (req: Request, res: Response) => {
     connection.query(query, function (err: Error, result: BowlTeam[]) {
       let bowlTeams = JSON.parse(JSON.stringify(result));
       let mergedResults = createBowlGames(bowlGames, bowlTeams);
-      res.send( { version: currentVersion, bowlData: mergedResults });
+      res.send({ version: currentVersion, bowlData: mergedResults });
     });
   });
 });

--- a/Server/src/routes/gameRoute.ts
+++ b/Server/src/routes/gameRoute.ts
@@ -75,6 +75,7 @@ gameRoute.get('/gameData/delta/:year', async (req: Request, res: Response) => {
   var version = 0;
   if (!isEmpty(req.query.version)) {
     version = parseInt(req.query.version as string);
+    version = version == 0 ? -1 : version;
   }
   let year = req.params['year'];
   let currentVersion = await getCurrentVersion(year);
@@ -82,8 +83,7 @@ gameRoute.get('/gameData/delta/:year', async (req: Request, res: Response) => {
   let query = `SELECT * FROM bowlGames 
                     WHERE homeTeam > ${teamIdRange.lowerBound} 
                     AND homeTeam < ${teamIdRange.upperBound}
-                    AND version > ${version}
-                    OR version = 0`;
+                    AND version > ${version}`;
   let values = [];
   connection.query(query, function (err: Error, results: BowlGame[]) {
     if (err) throw console.error(err);
@@ -91,8 +91,7 @@ gameRoute.get('/gameData/delta/:year', async (req: Request, res: Response) => {
     query = `SELECT * FROM bowlTeams 
                 WHERE teamId > ${teamIdRange.lowerBound} 
                 AND teamId < ${teamIdRange.upperBound}
-                AND version > ${version}
-                OR version = 0`;
+                AND version > ${version}`;
     connection.query(query, function (err: Error, result: BowlTeam[]) {
       let bowlTeams = JSON.parse(JSON.stringify(result));
       let mergedResults = createBowlGames(bowlGames, bowlTeams);

--- a/Server/src/routes/playerRoute.ts
+++ b/Server/src/routes/playerRoute.ts
@@ -52,7 +52,6 @@ playerRoute.get('/playerData/:year', async (req: Request, res: Response) => {
           JSON.parse(JSON.stringify(picks))
         );
         res.send({ version: currentVersion, players: mergedResults });
-        console.log('hello');
       });
     });
   } else {
@@ -70,10 +69,10 @@ playerRoute.get(
     let year = req.params['year'];
     let currentVersion = await getCurrentVersion(year);
     let playerIdRange = getTeamIdRange(year);
-    let query = `SELECT * FROM players WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound} AND version > ${version}`;
+    let query = `SELECT * FROM players WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound} AND version > ${version} OR version = 0`;
     connection.query(query, function (err: Error, players: Player[]) {
       if (err) throw console.error(err);
-      query = `SELECT * FROM playerPicks WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound}`;
+      query = `SELECT * FROM playerPicks WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound} AND version > ${version} OR version = 0`;
       connection.query(query, function (err: Error, picks: Pick[]) {
         if (err) throw console.error(err);
         let mergedResults = createPlayersPicks(
@@ -81,7 +80,6 @@ playerRoute.get(
           JSON.parse(JSON.stringify(picks))
         );
         res.send({ version: currentVersion, players: mergedResults });
-        console.log('hello');
       });
     });
   }

--- a/Server/src/routes/playerRoute.ts
+++ b/Server/src/routes/playerRoute.ts
@@ -62,17 +62,18 @@ playerRoute.get('/playerData/:year', async (req: Request, res: Response) => {
 playerRoute.get(
   '/playerData/delta/:year',
   async (req: Request, res: Response) => {
-    var version = 0;
+    var version = -1;
     if (!isEmpty(req.query.version)) {
       version = parseInt(req.query.version as string);
+      version = version == 0 ? -1 : version;
     }
     let year = req.params['year'];
     let currentVersion = await getCurrentVersion(year);
     let playerIdRange = getTeamIdRange(year);
-    let query = `SELECT * FROM players WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound} AND version > ${version} OR version = 0`;
+    let query = `SELECT * FROM players WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound} AND version > ${version}`;
     connection.query(query, function (err: Error, players: Player[]) {
       if (err) throw console.error(err);
-      query = `SELECT * FROM playerPicks WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound} AND version > ${version} OR version = 0`;
+      query = `SELECT * FROM playerPicks WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound} AND version > ${version}`;
       connection.query(query, function (err: Error, picks: Pick[]) {
         if (err) throw console.error(err);
         let mergedResults = createPlayersPicks(

--- a/Server/src/routes/playerRoute.ts
+++ b/Server/src/routes/playerRoute.ts
@@ -1,7 +1,8 @@
 import express, { Request, Response } from 'express';
 import { connection } from '../helpers/db';
 import { getTeamIdRange } from '../helpers/teamId';
-import _ from 'lodash';
+import _, { isEmpty } from 'lodash';
+import { getCurrentVersion } from './versionUtil';
 
 export interface Pick {
   pickId: number;
@@ -31,20 +32,57 @@ export function createPlayersPicks(players: Player[], picks: Pick[]) {
 }
 
 export const playerRoute = express.Router();
-playerRoute.get('/playerData/:year', (req: Request, res: Response) => {
-  let playerIdRange = getTeamIdRange(req.params['year']);
-  let query = `SELECT * FROM players WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound}`;
-  connection.query(query, function (err, players) {
-    if (err) throw console.error(err);
-    query = `SELECT * FROM playerPicks WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound}`;
-    connection.query(query, function (err, picks) {
+playerRoute.get('/playerData/:year', async (req: Request, res: Response) => {
+  var year = req.params['year'];
+  var version = 0;
+  if (!isEmpty(req.query.version)) {
+    version = parseInt(req.query.version as string);
+  }
+  let currentVersion = await getCurrentVersion(year);
+  if (version < currentVersion) {
+    let playerIdRange = getTeamIdRange(year);
+    let query = `SELECT * FROM players WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound}`;
+    connection.query(query, function (err: Error, players: Player[]) {
       if (err) throw console.error(err);
-      res.send(
-        createPlayersPicks(
+      query = `SELECT * FROM playerPicks WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound}`;
+      connection.query(query, function (err: Error, picks: Pick[]) {
+        if (err) throw console.error(err);
+        let mergedResults = createPlayersPicks(
           JSON.parse(JSON.stringify(players)),
           JSON.parse(JSON.stringify(picks))
-        )
-      );
+        );
+        res.send({ version: currentVersion, players: mergedResults });
+        console.log('hello');
+      });
     });
-  });
+  } else {
+    res.send({ version: currentVersion, players: [] });
+  }
 });
+
+playerRoute.get(
+  '/playerData/delta/:year',
+  async (req: Request, res: Response) => {
+    var version = 0;
+    if (!isEmpty(req.query.version)) {
+      version = parseInt(req.query.version as string);
+    }
+    let year = req.params['year'];
+    let currentVersion = await getCurrentVersion(year);
+    let playerIdRange = getTeamIdRange(year);
+    let query = `SELECT * FROM players WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound} AND version > ${version}`;
+    connection.query(query, function (err: Error, players: Player[]) {
+      if (err) throw console.error(err);
+      query = `SELECT * FROM playerPicks WHERE playerId > ${playerIdRange.lowerBound} AND playerId < ${playerIdRange.upperBound}`;
+      connection.query(query, function (err: Error, picks: Pick[]) {
+        if (err) throw console.error(err);
+        let mergedResults = createPlayersPicks(
+          JSON.parse(JSON.stringify(players)),
+          JSON.parse(JSON.stringify(picks))
+        );
+        res.send({ version: currentVersion, players: mergedResults });
+        console.log('hello');
+      });
+    });
+  }
+);


### PR DESCRIPTION
Versioned the playerData route getting inspiration from gameData. I included a delta route as well.

I also found and fixed a bug related to delta not pulling back data with a version set to 0. I included this check for if version = 0 and sets it for -1 which will pull back version 0. Basically if you have version 0 you should get all the data, otherwise you we won't ever send the data for version 0. 	

The reason it wasn't being pulled back is in our SQL query we use "version > ${version}" so if its "0 > 0" it will never pull it back, so setting it to -1 allows it to be pulled back "0 > -1". The problem with changing the query to "version >= ${version}" is we don't want to pull back the data if your version is current. 