### PR TITLE
BP-68: Fix web and docker after versioning

### DIFF
--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -19,3 +19,8 @@ EXPOSE 1313
 RUN yarn build
 
 COPY . .
+
+
+
+docker build -t bowlpool_web:master .
+docker build -t bowlpool_server:master .

--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -19,8 +19,3 @@ EXPOSE 1313
 RUN yarn build
 
 COPY . .
-
-
-
-docker build -t bowlpool_web:master .
-docker build -t bowlpool_server:master .

--- a/Web/Dockerfile
+++ b/Web/Dockerfile
@@ -23,4 +23,5 @@ WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*
 
 COPY --from=baseweb /home/node/app/build .
+EXPOSE 80
 ENTRYPOINT [ "nginx", "-g", "daemon off;" ]

--- a/Web/src/util/bowlpoolRepo.ts
+++ b/Web/src/util/bowlpoolRepo.ts
@@ -12,7 +12,7 @@ export class bowlpoolRepo {
       axios
         .get(`${this.url}/gameData/${year}`)
         .then((resp) => {
-          let data = resp.data;
+          let data = resp.data.bowlData;
           let sortedData = data.sort((a: BowlGame, b: BowlGame) => {
             return (
               new Date(a.startTime).valueOf() - new Date(b.startTime).valueOf()
@@ -29,7 +29,7 @@ export class bowlpoolRepo {
       axios
         .get(`${this.url}/playerData/${year}`)
         .then((resp) => {
-          let data = resp.data;
+          let data = resp.data.players;
           let sortedPlayers = data.sort(
             (a: Player, b: Player) => b.points - a.points
           );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: '3.6'
 
 services: 
   server:
-    build: 
-      context: ./Server
-      target: base
+    image: bowlpool_server:master
     env_file:
       - .env
     expose:
@@ -16,13 +14,10 @@ services:
   web:
     depends_on:
       - server
-    build: 
-      context: ./Web
-      target: baseweb
+    image: bowlpool_web:master
     env_file:
       - ./Web/.env
     expose:
       - "80"
     ports:
-      - "80:3000"
-    command: yarn start
+      - "80:80"


### PR DESCRIPTION
I updated the docker files to be more friendly for deployment. The compose now references images tagged to master and I have a command I run on the testing server to bump the image version. Would be nice to host these docker images somewhere, but I doubt we could do it for free and we dont really need it haha 

The issue was with the versioning update we changed the REST schema to now have version so it broke the frontend processing which assumed it didn't need to reference bowlData or players directly. 