### PR TITLE
BP-69: Implement Simple Versioning

### DIFF
--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -19,3 +19,8 @@ EXPOSE 1313
 RUN yarn build
 
 COPY . .
+
+
+
+docker build -t bowlpool_web:master .
+docker build -t bowlpool_server:master .

--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -19,8 +19,3 @@ EXPOSE 1313
 RUN yarn build
 
 COPY . .
-
-
-
-docker build -t bowlpool_web:master .
-docker build -t bowlpool_server:master .

--- a/Web/Dockerfile
+++ b/Web/Dockerfile
@@ -23,4 +23,5 @@ WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*
 
 COPY --from=baseweb /home/node/app/build .
+EXPOSE 80
 ENTRYPOINT [ "nginx", "-g", "daemon off;" ]

--- a/Web/src/util/bowlpoolRepo.ts
+++ b/Web/src/util/bowlpoolRepo.ts
@@ -12,7 +12,7 @@ export class bowlpoolRepo {
       axios
         .get(`${this.url}/gameData/${year}`)
         .then((resp) => {
-          let data = resp.data;
+          let data = resp.data.bowlData;
           let sortedData = data.sort((a: BowlGame, b: BowlGame) => {
             return (
               new Date(a.startTime).valueOf() - new Date(b.startTime).valueOf()
@@ -29,7 +29,7 @@ export class bowlpoolRepo {
       axios
         .get(`${this.url}/playerData/${year}`)
         .then((resp) => {
-          let data = resp.data;
+          let data = resp.data.players;
           let sortedPlayers = data.sort(
             (a: Player, b: Player) => b.points - a.points
           );

--- a/Web/src/util/bowlpoolRepo.ts
+++ b/Web/src/util/bowlpoolRepo.ts
@@ -8,32 +8,65 @@ export class bowlpoolRepo {
       : process.env.REACT_APP_API_URL;
 
   getGameData(year: number) {
+    let localGameData = localStorage.getItem('gameData' + year.toString());
+    let localGameVersion = localStorage.getItem('gameVersion') ?? 0;
+    let gameDataURL = localGameVersion
+      ? `${this.url}/gameData/${year}?version=${localGameVersion}`
+      : `${this.url}/gameData/${year}`;
     return new Promise<BowlGame[]>((resolve, reject) => {
       axios
-        .get(`${this.url}/gameData/${year}`)
+        .get(gameDataURL)
         .then((resp) => {
-          let data = resp.data.bowlData;
-          let sortedData = data.sort((a: BowlGame, b: BowlGame) => {
-            return (
-              new Date(a.startTime).valueOf() - new Date(b.startTime).valueOf()
+          let version = resp.data.version;
+          let data: BowlGame[];
+          if (version > localGameVersion) {
+            data = resp.data.bowlData;
+            let sortedData = data.sort((a: BowlGame, b: BowlGame) => {
+              return (
+                new Date(a.startTime).valueOf() -
+                new Date(b.startTime).valueOf()
+              );
+            });
+            localStorage.setItem(
+              'gameData' + year.toString(),
+              JSON.stringify(sortedData)
             );
-          });
-          resolve(sortedData);
+            localStorage.setItem('gameVersion', version);
+            resolve(sortedData);
+          } else if (localGameData) {
+            resolve(JSON.parse(localGameData));
+          }
         })
         .catch((resp) => alert(resp));
     });
   }
 
   getPlayerData(year: number) {
+    let localPlayerData = localStorage.getItem('playerData' + year.toString());
+    let localPlayerVersion = localStorage.getItem('playerVersion') ?? 0;
+    let playerDataURL = localPlayerVersion
+      ? `${this.url}/playerData/${year}?version=${localPlayerVersion}`
+      : `${this.url}/playerData/${year}`;
     return new Promise<Player[]>((resolve, reject) => {
       axios
-        .get(`${this.url}/playerData/${year}`)
+        .get(playerDataURL)
         .then((resp) => {
-          let data = resp.data.players;
-          let sortedPlayers = data.sort(
-            (a: Player, b: Player) => b.points - a.points
-          );
-          resolve(sortedPlayers);
+          let version = resp.data.version;
+          let data: Player[];
+          if (version > localPlayerVersion) {
+            data = resp.data.players;
+            let sortedPlayers = data.sort(
+              (a: Player, b: Player) => b.points - a.points
+            );
+            localStorage.setItem(
+              'playerData' + year.toString(),
+              JSON.stringify(sortedPlayers)
+            );
+            localStorage.setItem('playerVersion', version);
+            resolve(sortedPlayers);
+          } else if (localPlayerData) {
+            resolve(JSON.parse(localPlayerData));
+          }
         })
         .catch((resp) => alert(resp));
     });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: '3.6'
 
 services: 
   server:
-    build: 
-      context: ./Server
-      target: base
+    image: bowlpool_server:master
     env_file:
       - .env
     expose:
@@ -16,13 +14,10 @@ services:
   web:
     depends_on:
       - server
-    build: 
-      context: ./Web
-      target: baseweb
+    image: bowlpool_web:master
     env_file:
       - ./Web/.env
     expose:
       - "80"
     ports:
-      - "80:3000"
-    command: yarn start
+      - "80:80"


### PR DESCRIPTION
Implemented local storage for simple versioning. If the local version is less than server version then we update the data and version. I ran into an issue where if getGameData ran slightly before getPlayerData it would update the local storage version. I decided for now to just flag each version separately even though they likely will be the same. 