### PR TITLE
BP-89-removeEmptylines

### DIFF
--- a/Web/src/components/table/BowlpoolTableAwayRow.tsx
+++ b/Web/src/components/table/BowlpoolTableAwayRow.tsx
@@ -33,7 +33,7 @@ export const BowlpoolTableAwayRow: React.FC<BowlpoolTableAwayRowProps> = (
       </th>
       {!props.hideBowlData && <th id="away">{props.game.awayTeam.record}</th>}
       <th id="away">
-        {props.game.awayTeam.line
+        {props.game.awayTeam.line && props.game.awayTeam.line !== '0'
           ? props.game.awayTeam.score || props.game.homeTeam.score
             ? `${props.game.awayTeam.score} (${props.game.awayTeam.line})`
             : `N/A (${props.game.awayTeam.line})`

--- a/Web/src/components/table/BowlpoolTableHomeRow.tsx
+++ b/Web/src/components/table/BowlpoolTableHomeRow.tsx
@@ -20,7 +20,7 @@ export const BowlpoolTableHomeRow: React.FC<BowlpoolTableHomeRowProps> = (
       <th scope="row">Home: {props.game.homeTeam.name}</th>
       {!props.hideBowlData && <th>{props.game.homeTeam.record}</th>}
       <th>
-        {props.game.homeTeam.line
+        {props.game.homeTeam.line && props.game.homeTeam.line !== '0'
           ? props.game.homeTeam.score || props.game.awayTeam.score
             ? `${props.game.homeTeam.score} (${props.game.homeTeam.line})`
             : `N/A (${props.game.homeTeam.line})`


### PR DESCRIPTION
<img width="108" alt="Screenshot 2023-12-18 at 4 25 10 PM" src="https://github.com/Bowlpool/HarrysBowlpool/assets/10173121/0690bf04-c709-43dc-82b9-7e6e17ef2706">

We would show the line and 0 for teams without a line. Removed the 0 as its not necessary.